### PR TITLE
Add whereDoesntHaveMeta method to the builder

### DIFF
--- a/docs/source/querying_meta.rst
+++ b/docs/source/querying_meta.rst
@@ -23,6 +23,14 @@ If you would like to restrict your query to only return models with meta for `al
     <?php
     $models = MyModel::whereHasMetaKeys(['step1', 'step2', 'step3'])->get();
 
+You can also query for records that does not contain a meta key using the ``whereDoesntHaveMeta()``. It's signature is identical to that of ``whereHasMeta()`.
+
+::
+
+    <?php 
+    $models = MyModel::whereDoesntHaveMeta('notes')->get();
+    $models = MyModel::whereDoesntHaveMeta(['queued_at', 'sent_at'])->get();
+
 Comparing value
 ---------------
 

--- a/src/Metable.php
+++ b/src/Metable.php
@@ -179,6 +179,23 @@ trait Metable
     }
 
     /**
+     * Query scope to restrict the query to records which doesnt have `Meta` attached to a given key.
+     *
+     * If an array of keys is passed instead, will restrict the query to records having one or more Meta with any of the keys.
+     *
+     * @param Builder      $q
+     * @param string|array $key
+     *
+     * @return void
+     */
+    public function scopeWhereDoesntHaveMeta(Builder $q, $key)
+    {
+        $q->whereDoesntHave('meta', function (Builder $q) use ($key) {
+            $q->whereIn('key', (array) $key);
+        });
+    }
+
+    /**
      * Query scope to restrict the query to records which have `Meta` for all of the provided keys.
      *
      * @param Builder $q

--- a/tests/integration/MetableTest.php
+++ b/tests/integration/MetableTest.php
@@ -136,6 +136,21 @@ class MetableTest extends TestCase
         $this->assertEquals($metable->getKey(), $result->getKey());
     }
 
+    public function test_it_can_be_queried_by_missing_single_meta_key()
+    {
+        $this->useDatabase();
+        $metable = factory(SampleMetable::class)->create();
+        $metable->setMeta('foo', 'bar');
+
+        $metable2 = factory(SampleMetable::class)->create();
+        $metable2->setMeta('bar', 'foo');
+
+        $result = SampleMetable::whereDoesntHaveMeta('foo')->first();
+
+        $this->assertEquals($metable2->getKey(), $result->getKey());
+        $this->assertNotEquals($metable->getKey(), $result->getKey());
+    }
+
     public function test_it_can_be_queried_by_any_meta_keys()
     {
         $this->useDatabase();
@@ -148,6 +163,27 @@ class MetableTest extends TestCase
 
         $this->assertEquals($metable->getKey(), $result1->getKey());
         $this->assertEquals($metable->getKey(), $result2->getKey());
+    }
+
+    public function test_it_can_be_queried_by_any_missing_meta_keys()
+    {
+        $this->useDatabase();
+        $metable = factory(SampleMetable::class)->create();
+        $metable->setMeta('foo', 'bar');
+        $metable->setMeta('baz', 'bat');
+
+        $metable2 = factory(SampleMetable::class)->create();
+        $metable2->setMeta('bee', 'bop');
+        $metable2->setMeta('bop', 'bee');
+
+        $result1 = SampleMetable::whereDoesntHaveMeta(['foo', 'baz'])->first();
+        $result2 = SampleMetable::whereDoesntHaveMeta(['foo', 'zzz'])->first();
+
+        $this->assertEquals($metable2->getKey(), $result1->getKey());
+        $this->assertEquals($metable2->getKey(), $result2->getKey());
+
+        $this->assertNotEquals($metable->getKey(), $result1->getKey());
+        $this->assertNotEquals($metable->getKey(), $result2->getKey());
     }
 
     public function test_it_can_be_queried_by_all_meta_keys()


### PR DESCRIPTION
Adds the scope whereDoesntHaveMeta which queries records that does not have specific meta key.