### PR TITLE
Allow uppercase keys

### DIFF
--- a/src/Metable.php
+++ b/src/Metable.php
@@ -45,8 +45,6 @@ trait Metable
      */
     public function setMeta(string $key, $value)
     {
-        $key = strtolower($key);
-
         if ($this->hasMeta($key)) {
             $meta = $this->getMetaRecord($key);
             $meta->setAttribute('value', $value);

--- a/tests/integration/MetableTest.php
+++ b/tests/integration/MetableTest.php
@@ -16,6 +16,18 @@ class MetableTest extends TestCase
         $this->assertEquals('bar', $metable->getMeta('foo'));
     }
 
+    public function test_it_can_set_uppercase_key()
+    {
+        $this->useDatabase();
+        $metable = factory(SampleMetable::class)->create();
+
+        $metable->setMeta('FOO', 'bar');
+
+        $this->assertTrue($metable->hasMeta('FOO'));
+        $this->assertFalse($metable->hasMeta('foo'));
+        $this->assertEquals('bar', $metable->getMeta('FOO'));
+    }
+
     public function test_it_can_get_meta_record()
     {
         $this->useDatabase();


### PR DESCRIPTION
I have a use case where the key of a meta is a string consisting of uppercase and lowercase characters. Currently I have to convert key names to lower cases when using `setMeta`.
I don't really get why only lowercase keys are supported, so this PR removes the `strtolower` call.

Example:
```
$subject->setMeta('FOO', 'bar');
var_dump($subject->hasMeta('FOO')); // Returns false
var_dump($subject->hasMeta('foo')); // Returns true
```