### PR TITLE
joinMetaTable function now uses getMorphClass for Metable trait

### DIFF
--- a/src/Metable.php
+++ b/src/Metable.php
@@ -375,7 +375,7 @@ trait Metable
         $q->join("{$metaTable} as {$alias}", function (JoinClause $q) use ($relation, $key, $alias) {
             $q->on($relation->getQualifiedParentKeyName(), '=', $alias . '.' . $relation->getForeignKeyName())
                 ->where($alias . '.key', '=', $key)
-                ->where($alias . '.' . $relation->getMorphType(), '=', get_class($this));
+                ->where($alias . '.' . $relation->getMorphType(), '=', $this->getMorphClass());
         }, null, null, $type);
 
         // Return the alias so that the calling context can

--- a/tests/_data/classes/SampleMorph.php
+++ b/tests/_data/classes/SampleMorph.php
@@ -1,0 +1,16 @@
+<?php
+
+use Plank\Metable\Metable;
+
+class SampleMorph extends SampleMetable
+{
+    use Metable;
+
+    protected $table = 'sample_metables';
+
+    public function getMorphClass()
+    {
+        return SampleMetable::class;
+    }
+
+}

--- a/tests/_data/classes/SampleMorph.php
+++ b/tests/_data/classes/SampleMorph.php
@@ -12,5 +12,4 @@ class SampleMorph extends SampleMetable
     {
         return SampleMetable::class;
     }
-
 }

--- a/tests/_data/factories/MorphFactory.php
+++ b/tests/_data/factories/MorphFactory.php
@@ -1,0 +1,5 @@
+<?php
+
+$factory->define(SampleMorph::class, function (Faker\Generator $faker) {
+    return [];
+});

--- a/tests/integration/MorphTest.php
+++ b/tests/integration/MorphTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Plank\Metable\Meta;
+
+class MorphTest extends TestCase
+{
+    public function test_it_can_get_and_set_meta_value_by_key()
+    {
+        $this->useDatabase();
+        $child = $this->createChild();
+        $this->assertFalse($child->hasMeta('foo'));
+
+        $child->setMeta('foo', 'bar');
+
+        $this->assertTrue($child->hasMeta('foo'));
+        $this->assertEquals('bar', $child->getMeta('foo'));
+    }
+
+    public function test_it_can_get_meta_record()
+    {
+        $this->useDatabase();
+        $child = $this->createChild();
+        $child->setMeta('foo', 123);
+
+        $class = SampleMetable::class;
+        $record = $child->getMetaRecord('foo');
+
+        $this->assertEquals('foo', $record->key);
+        $this->assertEquals(123, $record->value);
+        $this->assertEquals($class, $record->metable_type);
+    }
+
+    public function test_it_can_join_correctly_from_morphed_class()
+    {
+        $this->useDatabase();
+        $metable1 = $this->createMetable(['id' => 1]);
+        $child2 = $this->createChild(['id' => 2]);
+        $child3 = $this->createChild(['id' => 3]);
+        $metable1->setMeta('foo', 'b');
+        $child2->setMeta('foo', 'c');
+        $child3->setMeta('foo', 'a');
+
+        $class = SampleMetable::class;
+        $results1 = SampleMorph::orderByMeta('foo', 'asc')->get();
+        $results2 = Meta::select('metable_type')->get();
+
+        $this->assertCount(3, $results1->pluck('id')->toArray());
+        $this->assertEquals([$class, $class, $class], $results2->pluck('metable_type')->toArray());
+    }
+
+    private function createMetable(array $attributes = []): SampleMetable
+    {
+        return factory(SampleMetable::class)->create($attributes);
+    }
+
+    private function createChild(array $attributes = []): SampleMorph
+    {
+        return factory(SampleMorph::class)->create($attributes);
+    }
+}


### PR DESCRIPTION
This resolves issues associated with using single table inheritance on classes that use the Metable  trait