### PR TITLE
Add Laravel 8.x support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
         }
     },
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.3.0",
         "ext-json": "*",
-        "illuminate/support": "^5.6|^6.0|^7.0|^8.0",
-        "illuminate/database": "^5.6|^6.0|^7.0|^8.0"
+        "illuminate/support": "^8.0",
+        "illuminate/database": "^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.3|^4.0|^5.0|^6.0",
-        "phpunit/phpunit": "^8.0|^9.0",
+        "orchestra/testbench": "^6.0",
+        "phpunit/phpunit": "^9.3",
         "php-coveralls/php-coveralls": "^2.1"
     },
     "autoload-dev":{

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     "require": {
         "php": ">=7.2.0",
         "ext-json": "*",
-        "illuminate/support": "^5.6|^6.0|^7.0",
-        "illuminate/database": "^5.6|^6.0|^7.0"
+        "illuminate/support": "^5.6|^6.0|^7.0|^8.0",
+        "illuminate/database": "^5.6|^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.3|^4.0|^5.0",
+        "orchestra/testbench": "^3.3|^4.0|^5.0|^6.0",
         "phpunit/phpunit": "^8.0|^9.0",
         "php-coveralls/php-coveralls": "^2.1"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,11 +14,11 @@
             <directory suffix=".php">./tests/integration/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory suffix=".php">./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
     <php>
         <ini name="display_errors" value="true"/>
     </php>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,10 +5,16 @@ use Plank\Metable\MetableServiceProvider;
 
 class TestCase extends BaseTestCase
 {
+    protected $metableFactory;
+    protected $metaFactory;
+    protected $morphFactory;
+
     public function setUp(): void
     {
         parent::setUp();
-        $this->withFactories(__DIR__ . '/_data/factories');
+        $this->metableFactory = new MetableFactory();
+        $this->metaFactory = new MetaFactory();
+        $this->morphFactory = new MorphFactory();
     }
 
     protected function getPackageProviders($app)

--- a/tests/_data/factories/MetaFactory.php
+++ b/tests/_data/factories/MetaFactory.php
@@ -1,5 +1,23 @@
 <?php
 
-$factory->define(Plank\Metable\Meta::class, function (Faker\Generator $faker) {
-    return [];
-});
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class MetaFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Plank\Metable\Meta::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [];
+    }
+}

--- a/tests/_data/factories/MetableFactory.php
+++ b/tests/_data/factories/MetableFactory.php
@@ -1,5 +1,23 @@
 <?php
 
-$factory->define(SampleMetable::class, function (Faker\Generator $faker) {
-    return [];
-});
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class MetableFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = SampleMetable::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [];
+    }
+}

--- a/tests/_data/factories/MorphFactory.php
+++ b/tests/_data/factories/MorphFactory.php
@@ -1,5 +1,23 @@
 <?php
 
-$factory->define(SampleMorph::class, function (Faker\Generator $faker) {
-    return [];
-});
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class MorphFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = SampleMorph::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [];
+    }
+}

--- a/tests/integration/DataType/ModelCollectionHandlerTest.php
+++ b/tests/integration/DataType/ModelCollectionHandlerTest.php
@@ -9,9 +9,9 @@ class ModelCollectionHandlerTest extends TestCase
     {
         $this->useDatabase();
 
-        $model1 = factory(SampleMetable::class)->create(['id' => 3]);
-        $model2 = factory(SampleMetable::class)->make([]);
-        $model3 = factory(SampleMetable::class)->create(['id' => 1]);
+        $model1 = $this->metableFactory->create(['id' => 3]);
+        $model2 = $this->metableFactory->make([]);
+        $model3 = $this->metableFactory->create(['id' => 1]);
         $collection = new Collection([$model1, $model2, 'foo' => $model3]);
         $handler = new ModelCollectionHandler();
 

--- a/tests/integration/DataType/ModelHandlerTest.php
+++ b/tests/integration/DataType/ModelHandlerTest.php
@@ -8,7 +8,7 @@ class ModelHandlerTest extends TestCase
     {
         $this->useDatabase();
 
-        $model = factory(SampleMetable::class)->create(['id' => 12]);
+        $model = $this->metableFactory->create(['id' => 12]);
         $handler = new ModelHandler();
 
         $serialized = $handler->serializeValue($model);

--- a/tests/integration/MetaTest.php
+++ b/tests/integration/MetaTest.php
@@ -59,6 +59,6 @@ class MetaTest extends TestCase
 
     private function makeMeta(array $attributes = []): Meta
     {
-        return factory(Meta::class)->make($attributes);
+        return $this->metaFactory->make($attributes);
     }
 }

--- a/tests/integration/MetableTest.php
+++ b/tests/integration/MetableTest.php
@@ -372,16 +372,16 @@ class MetableTest extends TestCase
 
     private function makeMeta(array $attributes = []): Meta
     {
-        return factory(Meta::class)->make($attributes);
+        return $this->metaFactory->make($attributes);
     }
 
     private function makeMetable(array $attributes = []): SampleMetable
     {
-        return factory(SampleMetable::class)->make($attributes);
+        return $this->metableFactory->make($attributes);
     }
 
     private function createMetable(array $attributes = []): SampleMetable
     {
-        return factory(SampleMetable::class)->create($attributes);
+        return $this->metableFactory->create($attributes);
     }
 }

--- a/tests/integration/MorphTest.php
+++ b/tests/integration/MorphTest.php
@@ -51,11 +51,11 @@ class MorphTest extends TestCase
 
     private function createMetable(array $attributes = []): SampleMetable
     {
-        return factory(SampleMetable::class)->create($attributes);
+        return $this->metableFactory->create($attributes);
     }
 
     private function createChild(array $attributes = []): SampleMorph
     {
-        return factory(SampleMorph::class)->create($attributes);
+        return $this->morphFactory->create($attributes);
     }
 }


### PR DESCRIPTION
No notable changes in Laravel 8.0, so just dependencies version bump is required.

Closes #30 