### PR TITLE
Add a warning to the `syncMeta()` docs about existing meta being deleted

### DIFF
--- a/docs/source/datatypes.rst
+++ b/docs/source/datatypes.rst
@@ -19,19 +19,19 @@ Arrays of scalar values. Nested arrays are supported.
 
 ::
 
-	<?php
-	$metable->setMeta('information', [
-		'address' => [
-			'street' => '123 Somewhere Ave.',
-			'city' => 'Somewhereville',
-			'country' => 'Somewhereland',
-			'postal' => '123456',
-		],
-		'contact' => [
-			'phone' => '555-555-5555',
-			'email' => 'email@example.com'
-		]
-	]);
+    <?php
+    $metable->setMeta('information', [
+        'address' => [
+            'street' => '123 Somewhere Ave.',
+            'city' => 'Somewhereville',
+            'country' => 'Somewhereland',
+            'postal' => '123456',
+        ],
+        'contact' => [
+            'phone' => '555-555-5555',
+            'email' => 'email@example.com'
+        ]
+    ]);
 
 .. warning:: Laravel-Metable uses ``json_encode()`` and ``json_decode()`` under the hood for array serialization. This will cause any objects nested within the array to be cast to an array.
 
@@ -40,40 +40,40 @@ Boolean
 
 ::
 
-	<?php
-	$metable->setMeta('accepted_promotion', true);
+    <?php
+    $metable->setMeta('accepted_promotion', true);
 
 Integer
 ^^^^^^^^
 
 ::
 
-	<?php
-	$metable->setMeta('likes', 9001);
+    <?php
+    $metable->setMeta('likes', 9001);
 
 Float
 ^^^^^^^^
 
 ::
 
-	<?php
-	$metable->setMeta('precision', 0.755);
+    <?php
+    $metable->setMeta('precision', 0.755);
 
 Null
 ^^^^^^^^
 
 ::
 
-	<?php
-	$metable->setMeta('linked_model', null);
+    <?php
+    $metable->setMeta('linked_model', null);
 
 String
 ^^^^^^^^
 
 ::
 
-	<?php
-	$metable->setMeta('attachment', '/var/www/html/public/attachment.pdf');
+    <?php
+    $metable->setMeta('attachment', '/var/www/html/public/attachment.pdf');
 
 Objects
 ---------------
@@ -89,9 +89,9 @@ It is possible to attach another Eloquent model to a ``Metable`` model.
 
 ::
 
-	<?php
-	$page = App\Page::where(['title' => 'Welcome'])->first();
-	$metable->setMeta('linked_model', $page);
+    <?php
+    $page = App\Page::where(['title' => 'Welcome'])->first();
+    $metable->setMeta('linked_model', $page);
 
 When ``$metable->getMeta()`` is called, the attached model will be reloaded from the database.
 
@@ -99,8 +99,8 @@ It is also possible to attach a ``Model`` instance that has not been saved to th
 
 ::
 
-	<?php
-	$metable->setMeta('related', new App\Page);
+    <?php
+    $metable->setMeta('related', new App\Page);
 
 When ``$metable->getMeta()`` is called, a fresh instance of the class will be created (will not include any attributes).
 
@@ -114,9 +114,9 @@ As with individual models, both existing and unsaved instances can be stored.
 
 ::
 
-	<?php
-	$users = App\User::where(['title' => 'developer'])->get();
-	$metable->setMeta('authorized', $users);
+    <?php
+    $users = App\User::where(['title' => 'developer'])->get();
+    $metable->setMeta('authorized', $users);
 
 DateTime & Carbon
 ^^^^^^^^^^^^^^^^^^
@@ -125,8 +125,8 @@ Any object implementing the ``DateTimeInterface``.  Object will be converted to 
 
 ::
 
-	<?php
-	$metable->setMeta('last_viewed', \Carbon\Carbon::now());
+    <?php
+    $metable->setMeta('last_viewed', \Carbon\Carbon::now());
 
 
 Serializable
@@ -136,15 +136,15 @@ Any object implementing the PHP ``Serializable`` interface.
 
 ::
 
-	<?php
-	class Example implements \Serializable
-	{
-		//...
-	}
+    <?php
+    class Example implements \Serializable
+    {
+        //...
+    }
 
-	$serializable = new Example;
+    $serializable = new Example;
 
-	$metable->setMeta('example', $serializable);
+    $metable->setMeta('example', $serializable);
 
 Plain Objects
 ^^^^^^^^^^^^^^
@@ -153,9 +153,9 @@ Any other objects will be converted to ``stdClass`` plain objects. You can contr
 
 ::
 
-	<?php
-	$metable->setMeta('weight', new Weight(10, 'kg'));
-	$weight = $metable->getMeta('weight') // stdClass($amount = 10; $unit => 'kg');
+    <?php
+    $metable->setMeta('weight', new Weight(10, 'kg'));
+    $weight = $metable->getMeta('weight') // stdClass($amount = 10; $unit => 'kg');
 
 .. note:: The ``Plank\Metable\DataType\ObjectHandler`` class should always be the last entry the ``config/metable.php`` datatypes array, as it will accept any object, causing any handlers below it to be ignored.
 

--- a/docs/source/handling_meta.rst
+++ b/docs/source/handling_meta.rst
@@ -44,6 +44,8 @@ To set multiple meta key and value pairs at once, you can pass an associative ar
 		'age' => 18,
 	]);
 
+.. warning:: ``syncMeta()`` first deletes any existing meta on the model and then replaces it with the new meta. If you need to keep any existing meta, use individual ``setMeta()`` calls.
+
 Retrieving Meta
 ---------------
 

--- a/docs/source/handling_meta.rst
+++ b/docs/source/handling_meta.rst
@@ -7,19 +7,19 @@ before you can attach meta to an Eloquent model, you must first add the ``Metabl
 
 ::
 
-	<?php
+    <?php
 
-	namespace App;
+    namespace App;
 
-	use Plank\Metable\Metable;
-	use Illuminate\Database\Eloquent\Model;
+    use Plank\Metable\Metable;
+    use Illuminate\Database\Eloquent\Model;
 
-	class Page extends Model
-	{
-		use Metable;
+    class Page extends Model
+    {
+        use Metable;
 
-		// ...
-	}
+        // ...
+    }
 
 .. note::
     The Metable trait adds a ``meta()`` relationship to the model. However, it also keeps meta keys indexed separately to speed up reads. As such, it is recommended to not modify this relationship directly and to instead only use the methods described in this document.
@@ -31,18 +31,18 @@ Attach meta to a model with the ``setMeta()`` method. The method accepts two arg
 
 ::
 
-	<?php
-	$model->setMeta('key', 'value');
+    <?php
+    $model->setMeta('key', 'value');
 
 To set multiple meta key and value pairs at once, you can pass an associative array or collection to ``syncMeta()``.
 
 ::
 
-	<?php
-	$model->syncMeta([
-		'name' => 'John Doe',
-		'age' => 18,
-	]);
+    <?php
+    $model->syncMeta([
+        'name' => 'John Doe',
+        'age' => 18,
+    ]);
 
 .. warning:: ``syncMeta()`` first deletes any existing meta on the model and then replaces it with the new meta. If you need to keep any existing meta, use individual ``setMeta()`` calls.
 
@@ -53,20 +53,20 @@ You can retrieve the value of the meta at a given key with the ``getMeta()`` met
 
 ::
 
-	<?php
+    <?php
 
-	$model->setMeta('age', 18);
-	$model->setMeta('approved', true);
-	$model->setMeta('accessed_at', Carbon::now());
+    $model->setMeta('age', 18);
+    $model->setMeta('approved', true);
+    $model->setMeta('accessed_at', Carbon::now());
 
-	//reload the model from the database
-	$model = $model->fresh();
+    //reload the model from the database
+    $model = $model->fresh();
 
-	$age = $model->getMeta('age'); //returns an integer
-	$approved = $model->getMeta('approved'); //returns a boolean
-	$accessDate = $model->getMeta('accessed_at'); //returns a Carbon instance
+    $age = $model->getMeta('age'); //returns an integer
+    $approved = $model->getMeta('approved'); //returns a boolean
+    $accessDate = $model->getMeta('accessed_at'); //returns a Carbon instance
 
-	//etc.
+    //etc.
 
 Once loaded, all meta attached to a model instance are cached in the model's ``meta`` relationship. As such, successive calls to ``getMeta()`` will not hit the database repeatedly.
 
@@ -81,30 +81,30 @@ You may pass a second parameter to the ``getMeta()`` method in order to specify 
 
 ::
 
-	<?php
-	$model->getMeta('status', 'draft'); // will return 'draft' if not set
-	
+    <?php
+    $model->getMeta('status', 'draft'); // will return 'draft' if not set
+
 Alternatively, you may set default values as key-value pairs on the model itself, instead of specifying them at each individual call site. If a default has been defined from this property and a value is also passed as to the default parameter, the parameter will take precedence.
 
 ::
 
-	<?php
-	class ExampleMetable extends Model {
-		use Metable;
-		
-		protected $defaultMetaValues = [
-			'color' => '#000000'
-		];
-		
-		//...
-	}
+    <?php
+    class ExampleMetable extends Model {
+        use Metable;
+
+        protected $defaultMetaValues = [
+            'color' => '#000000'
+        ];
+
+        //...
+    }
 ::
 
-	<?php
-	$model->getMeta('color'); // will return '#000000' if not set
-	$model->getMeta('color', null); // will return null if not set
-	$model->getMeta('color', '#ffffff'); // will return '#ffffff' if not set
-	
+    <?php
+    $model->getMeta('color'); // will return '#000000' if not set
+    $model->getMeta('color', null); // will return null if not set
+    $model->getMeta('color', '#ffffff'); // will return '#ffffff' if not set
+
 
 .. note:: If a falsey value (e.g. ``0``, ``false``, ``null``, ``''``) has been manually set for the key, that value will be returned instead of the default value. The default value will only be returned if no meta exists at the key.
 
@@ -126,10 +126,10 @@ You can check if a value has been assigned to a given key with the ``hasMeta()``
 
 ::
 
-	<?php
-	if ($model->hasMeta('background-color')) {
-		// ...
-	}
+    <?php
+    if ($model->hasMeta('background-color')) {
+        // ...
+    }
 
 .. note:: This method will return ``true`` even if a falsey value (e.g. ``0``, ``false``, ``null``, ``''``) has been manually set for the key.
 
@@ -141,14 +141,14 @@ To remove the meta stored at a given key, use ``removeMeta()``.
 
 ::
 
-	<?php
+    <?php
     $model->removeMeta('prefered_language');
 
 To Remove all meta from a model, use ``purgeMeta()``.
 
 ::
 
-	<?php
+    <?php
     $model->purgeMeta();
 
 Attached meta is automatically purged from the database when a ``Metable`` model is manually deleted. Meta will `not` be cascaded if the model is deleted by the query builder.

--- a/docs/source/querying_meta.rst
+++ b/docs/source/querying_meta.rst
@@ -23,7 +23,7 @@ If you would like to restrict your query to only return models with meta for `al
     <?php
     $models = MyModel::whereHasMetaKeys(['step1', 'step2', 'step3'])->get();
 
-You can also query for records that does not contain a meta key using the ``whereDoesntHaveMeta()``. It's signature is identical to that of ``whereHasMeta()`.
+You can also query for records that does not contain a meta key using the ``whereDoesntHaveMeta()``. Its signature is identical to that of ``whereHasMeta()``.
 
 ::
 


### PR DESCRIPTION
**EDIT:** Please review #41 before you review this one 👍🏻

This is a very important thing for people to know! The docs make it sound like you can use `syncMeta()` instead of multiple calls to `setMeta()` when you need to add multiple meta values, but they make no mention of it truly being a _sync_. That's not a fun one to accidentally discover...trust me 😁

I also fixed a typo I found in the docs (a missing backtick on a method name), and replaced all leading tabs with spaces in code samples. I noticed this in the rendered docs and found that it was happening because the first line was indented with a tab and the second was using spaces:

![image](https://user-images.githubusercontent.com/748444/100529176-da7c3180-31a1-11eb-857c-046cdd022c61.png)

Thanks!