### PR TITLE
Add `setManyMeta()` and `removeManyMeta()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ use Plank\Metable\Metable;
 
 class Post extends Model
 {
-	use Metable;
+    use Metable;
 
-	//...
+    //...
 }
 ```
 

--- a/docs/source/datatypes.rst
+++ b/docs/source/datatypes.rst
@@ -19,19 +19,19 @@ Arrays of scalar values. Nested arrays are supported.
 
 ::
 
-	<?php
-	$metable->setMeta('information', [
-		'address' => [
-			'street' => '123 Somewhere Ave.',
-			'city' => 'Somewhereville',
-			'country' => 'Somewhereland',
-			'postal' => '123456',
-		],
-		'contact' => [
-			'phone' => '555-555-5555',
-			'email' => 'email@example.com'
-		]
-	]);
+    <?php
+    $metable->setMeta('information', [
+        'address' => [
+            'street' => '123 Somewhere Ave.',
+            'city' => 'Somewhereville',
+            'country' => 'Somewhereland',
+            'postal' => '123456',
+        ],
+        'contact' => [
+            'phone' => '555-555-5555',
+            'email' => 'email@example.com'
+        ]
+    ]);
 
 .. warning:: Laravel-Metable uses ``json_encode()`` and ``json_decode()`` under the hood for array serialization. This will cause any objects nested within the array to be cast to an array.
 
@@ -40,40 +40,40 @@ Boolean
 
 ::
 
-	<?php
-	$metable->setMeta('accepted_promotion', true);
+    <?php
+    $metable->setMeta('accepted_promotion', true);
 
 Integer
 ^^^^^^^^
 
 ::
 
-	<?php
-	$metable->setMeta('likes', 9001);
+    <?php
+    $metable->setMeta('likes', 9001);
 
 Float
 ^^^^^^^^
 
 ::
 
-	<?php
-	$metable->setMeta('precision', 0.755);
+    <?php
+    $metable->setMeta('precision', 0.755);
 
 Null
 ^^^^^^^^
 
 ::
 
-	<?php
-	$metable->setMeta('linked_model', null);
+    <?php
+    $metable->setMeta('linked_model', null);
 
 String
 ^^^^^^^^
 
 ::
 
-	<?php
-	$metable->setMeta('attachment', '/var/www/html/public/attachment.pdf');
+    <?php
+    $metable->setMeta('attachment', '/var/www/html/public/attachment.pdf');
 
 Objects
 ---------------
@@ -89,9 +89,9 @@ It is possible to attach another Eloquent model to a ``Metable`` model.
 
 ::
 
-	<?php
-	$page = App\Page::where(['title' => 'Welcome'])->first();
-	$metable->setMeta('linked_model', $page);
+    <?php
+    $page = App\Page::where(['title' => 'Welcome'])->first();
+    $metable->setMeta('linked_model', $page);
 
 When ``$metable->getMeta()`` is called, the attached model will be reloaded from the database.
 
@@ -99,8 +99,8 @@ It is also possible to attach a ``Model`` instance that has not been saved to th
 
 ::
 
-	<?php
-	$metable->setMeta('related', new App\Page);
+    <?php
+    $metable->setMeta('related', new App\Page);
 
 When ``$metable->getMeta()`` is called, a fresh instance of the class will be created (will not include any attributes).
 
@@ -114,9 +114,9 @@ As with individual models, both existing and unsaved instances can be stored.
 
 ::
 
-	<?php
-	$users = App\User::where(['title' => 'developer'])->get();
-	$metable->setMeta('authorized', $users);
+    <?php
+    $users = App\User::where(['title' => 'developer'])->get();
+    $metable->setMeta('authorized', $users);
 
 DateTime & Carbon
 ^^^^^^^^^^^^^^^^^^
@@ -125,8 +125,8 @@ Any object implementing the ``DateTimeInterface``.  Object will be converted to 
 
 ::
 
-	<?php
-	$metable->setMeta('last_viewed', \Carbon\Carbon::now());
+    <?php
+    $metable->setMeta('last_viewed', \Carbon\Carbon::now());
 
 
 Serializable
@@ -136,15 +136,15 @@ Any object implementing the PHP ``Serializable`` interface.
 
 ::
 
-	<?php
-	class Example implements \Serializable
-	{
-		//...
-	}
+    <?php
+    class Example implements \Serializable
+    {
+        //...
+    }
 
-	$serializable = new Example;
+    $serializable = new Example;
 
-	$metable->setMeta('example', $serializable);
+    $metable->setMeta('example', $serializable);
 
 Plain Objects
 ^^^^^^^^^^^^^^
@@ -153,9 +153,9 @@ Any other objects will be converted to ``stdClass`` plain objects. You can contr
 
 ::
 
-	<?php
-	$metable->setMeta('weight', new Weight(10, 'kg'));
-	$weight = $metable->getMeta('weight') // stdClass($amount = 10; $unit => 'kg');
+    <?php
+    $metable->setMeta('weight', new Weight(10, 'kg'));
+    $weight = $metable->getMeta('weight') // stdClass($amount = 10; $unit => 'kg');
 
 .. note:: The ``Plank\Metable\DataType\ObjectHandler`` class should always be the last entry the ``config/metable.php`` datatypes array, as it will accept any object, causing any handlers below it to be ignored.
 

--- a/docs/source/handling_meta.rst
+++ b/docs/source/handling_meta.rst
@@ -34,15 +34,25 @@ Attach meta to a model with the ``setMeta()`` method. The method accepts two arg
     <?php
     $model->setMeta('key', 'value');
 
-To set multiple meta key and value pairs at once, you can pass an associative array or collection to ``syncMeta()``.
+To set multiple meta key and value pairs at once, you can pass an associative array or collection to ``setManyMeta()``. The meta will be added to the model.
 
 ::
 
-	<?php
-	$model->syncMeta([
-		'name' => 'John Doe',
-		'age' => 18,
-	]);
+    <?php
+    $model->setManyMeta([
+        'name' => 'John Doe',
+        'age' => 18,
+    ]);
+
+To replace existing meta with a new set of meta, you can pass an associative array or collection to ``syncMeta()``. **All existing meta will be removed before the new meta is attached.**
+
+::
+
+    <?php
+    $model->syncMeta([
+        'name' => 'John Doe',
+        'age' => 18,
+    ]);
 
 Retrieving Meta
 ---------------
@@ -139,10 +149,21 @@ To remove the meta stored at a given key, use ``removeMeta()``.
 
 ::
 
-	<?php
-    $model->removeMeta('prefered_language');
+    <?php
+    $model->removeMeta('preferred_language');
 
-To Remove all meta from a model, use ``purgeMeta()``.
+To remove multiple meta at once, you can pass an array of keys to ``removeManyMeta()``.
+
+::
+
+    <?php
+    $model->removeManyMeta([
+        'preferred_language',
+        'store_currency',
+        'user_timezone',
+    ]);
+
+To remove all meta from a model, use ``purgeMeta()``.
 
 ::
 

--- a/docs/source/handling_meta.rst
+++ b/docs/source/handling_meta.rst
@@ -7,19 +7,19 @@ before you can attach meta to an Eloquent model, you must first add the ``Metabl
 
 ::
 
-	<?php
+    <?php
 
-	namespace App;
+    namespace App;
 
-	use Plank\Metable\Metable;
-	use Illuminate\Database\Eloquent\Model;
+    use Plank\Metable\Metable;
+    use Illuminate\Database\Eloquent\Model;
 
-	class Page extends Model
-	{
-		use Metable;
+    class Page extends Model
+    {
+        use Metable;
 
-		// ...
-	}
+        // ...
+    }
 
 .. note::
     The Metable trait adds a ``meta()`` relationship to the model. However, it also keeps meta keys indexed separately to speed up reads. As such, it is recommended to not modify this relationship directly and to instead only use the methods described in this document.
@@ -31,8 +31,8 @@ Attach meta to a model with the ``setMeta()`` method. The method accepts two arg
 
 ::
 
-	<?php
-	$model->setMeta('key', 'value');
+    <?php
+    $model->setMeta('key', 'value');
 
 To set multiple meta key and value pairs at once, you can pass an associative array or collection to ``syncMeta()``.
 
@@ -51,20 +51,20 @@ You can retrieve the value of the meta at a given key with the ``getMeta()`` met
 
 ::
 
-	<?php
+    <?php
 
-	$model->setMeta('age', 18);
-	$model->setMeta('approved', true);
-	$model->setMeta('accessed_at', Carbon::now());
+    $model->setMeta('age', 18);
+    $model->setMeta('approved', true);
+    $model->setMeta('accessed_at', Carbon::now());
 
-	//reload the model from the database
-	$model = $model->fresh();
+    //reload the model from the database
+    $model = $model->fresh();
 
-	$age = $model->getMeta('age'); //returns an integer
-	$approved = $model->getMeta('approved'); //returns a boolean
-	$accessDate = $model->getMeta('accessed_at'); //returns a Carbon instance
+    $age = $model->getMeta('age'); //returns an integer
+    $approved = $model->getMeta('approved'); //returns a boolean
+    $accessDate = $model->getMeta('accessed_at'); //returns a Carbon instance
 
-	//etc.
+    //etc.
 
 Once loaded, all meta attached to a model instance are cached in the model's ``meta`` relationship. As such, successive calls to ``getMeta()`` will not hit the database repeatedly.
 
@@ -79,30 +79,30 @@ You may pass a second parameter to the ``getMeta()`` method in order to specify 
 
 ::
 
-	<?php
-	$model->getMeta('status', 'draft'); // will return 'draft' if not set
-	
+    <?php
+    $model->getMeta('status', 'draft'); // will return 'draft' if not set
+
 Alternatively, you may set default values as key-value pairs on the model itself, instead of specifying them at each individual call site. If a default has been defined from this property and a value is also passed as to the default parameter, the parameter will take precedence.
 
 ::
 
-	<?php
-	class ExampleMetable extends Model {
-		use Metable;
-		
-		protected $defaultMetaValues = [
-			'color' => '#000000'
-		];
-		
-		//...
-	}
+    <?php
+    class ExampleMetable extends Model {
+        use Metable;
+
+        protected $defaultMetaValues = [
+            'color' => '#000000'
+        ];
+
+        //...
+    }
 ::
 
-	<?php
-	$model->getMeta('color'); // will return '#000000' if not set
-	$model->getMeta('color', null); // will return null if not set
-	$model->getMeta('color', '#ffffff'); // will return '#ffffff' if not set
-	
+    <?php
+    $model->getMeta('color'); // will return '#000000' if not set
+    $model->getMeta('color', null); // will return null if not set
+    $model->getMeta('color', '#ffffff'); // will return '#ffffff' if not set
+
 
 .. note:: If a falsey value (e.g. ``0``, ``false``, ``null``, ``''``) has been manually set for the key, that value will be returned instead of the default value. The default value will only be returned if no meta exists at the key.
 
@@ -124,10 +124,10 @@ You can check if a value has been assigned to a given key with the ``hasMeta()``
 
 ::
 
-	<?php
-	if ($model->hasMeta('background-color')) {
-		// ...
-	}
+    <?php
+    if ($model->hasMeta('background-color')) {
+        // ...
+    }
 
 .. note:: This method will return ``true`` even if a falsey value (e.g. ``0``, ``false``, ``null``, ``''``) has been manually set for the key.
 
@@ -146,7 +146,7 @@ To Remove all meta from a model, use ``purgeMeta()``.
 
 ::
 
-	<?php
+    <?php
     $model->purgeMeta();
 
 Attached meta is automatically purged from the database when a ``Metable`` model is manually deleted. Meta will `not` be cascaded if the model is deleted by the query builder.

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -18,33 +18,33 @@ Installation
 
 ::
 
-	composer require plank/laravel-metable
+    composer require plank/laravel-metable
 
 
 2. Register the package's service provider in ``config/app.php``. In Laravel versions 5.5 and beyond, this step can be skipped if package auto-discovery is enabled.
 
 ::
 
-	<?php
-	'providers' => [
-	    ...
-	    Plank\Metable\MetableServiceProvider::class,
-	    ...
-	];
+    <?php
+    'providers' => [
+        ...
+        Plank\Metable\MetableServiceProvider::class,
+        ...
+    ];
 
 
 3. Publish the config file (``config/metable.php``) of the package using artisan.
 
 ::
 
-	php artisan vendor:publish --provider="Plank\Metable\MetableServiceProvider"
+    php artisan vendor:publish --provider="Plank\Metable\MetableServiceProvider"
 
 
 4. Run the migrations to add the required table to your database.
 
 ::
 
-	php artisan migrate
+    php artisan migrate
 
 
 5. Add the `Plank\\Metable\\Metable <https://github.com/plank/laravel-metable/blob/master/src/Metable.php>`_ trait to any eloquent model class that you want to be able to attach metadata to.
@@ -56,21 +56,21 @@ Attach some metadata to an eloquent model
 
 ::
 
-	<?php
-	$post = Post::create($this->request->input());
-	$post->setMeta('color', 'blue');
+    <?php
+    $post = Post::create($this->request->input());
+    $post->setMeta('color', 'blue');
 
 
 Query the model by its metadata
 
 ::
 
-	<?php
-	$post = Post::whereMeta('color', 'blue');
+    <?php
+    $post = Post::whereMeta('color', 'blue');
 
 Retrieve the metadata from a model
 
 ::
 
-	<?php
-	$value = $post->getMeta('color');
+    <?php
+    $value = $post->getMeta('color');

--- a/docs/source/querying_meta.rst
+++ b/docs/source/querying_meta.rst
@@ -23,7 +23,7 @@ If you would like to restrict your query to only return models with meta for `al
     <?php
     $models = MyModel::whereHasMetaKeys(['step1', 'step2', 'step3'])->get();
 
-You can also query for records that does not contain a meta key using the ``whereDoesntHaveMeta()``. It's signature is identical to that of ``whereHasMeta()`.
+You can also query for records that does not contain a meta key using the ``whereDoesntHaveMeta()``. Its signature is identical to that of ``whereHasMeta()``.
 
 ::
 

--- a/src/Metable.php
+++ b/src/Metable.php
@@ -76,6 +76,20 @@ trait Metable
     }
 
     /**
+     * Add or update many `Meta` values.
+     *
+     * @param array|Traversable $array
+     *
+     * @return void
+     */
+    public function setManyMeta($array): void
+    {
+        foreach ($array as $key => $value) {
+            $this->setMeta($key, $value);
+        }
+    }
+
+    /**
      * Replace all associated `Meta` with the keys and values provided.
      *
      * @param array|Traversable $array
@@ -178,6 +192,20 @@ trait Metable
     public function removeMeta(string $key): void
     {
         $this->getMetaCollection()->pull($key)->delete();
+    }
+
+    /**
+     * Delete many `Meta` keys.
+     *
+     * @param array|string[]|Traversable $keys
+     *
+     * @return void
+     */
+    public function removeManyMeta($keys): void
+    {
+        foreach ($keys as $key) {
+            $this->removeMeta($key);
+        }
     }
 
     /**

--- a/tests/Integration/MetableTest.php
+++ b/tests/Integration/MetableTest.php
@@ -22,6 +22,28 @@ class MetableTest extends TestCase
         $this->assertEquals('bar', $metable->getMeta('foo'));
     }
 
+    public function test_it_can_set_many_meta_values_at_once()
+    {
+        $this->useDatabase();
+        $metable = $this->createMetable();
+        $this->assertFalse($metable->hasMeta('foo'));
+        $this->assertFalse($metable->hasMeta('bar'));
+        $this->assertFalse($metable->hasMeta('baz'));
+
+        $metable->setManyMeta([
+            'foo' => 'bar',
+            'bar' => 'baz',
+            'baz' => 'foo',
+        ]);
+
+        $this->assertTrue($metable->hasMeta('foo'));
+        $this->assertTrue($metable->hasMeta('bar'));
+        $this->assertTrue($metable->hasMeta('baz'));
+        $this->assertEquals('bar', $metable->getMeta('foo'));
+        $this->assertEquals('baz', $metable->getMeta('bar'));
+        $this->assertEquals('foo', $metable->getMeta('baz'));
+    }
+
     public function test_it_can_set_uppercase_key()
     {
         $this->useDatabase();
@@ -116,6 +138,27 @@ class MetableTest extends TestCase
 
         $this->assertFalse($metable->hasMeta('foo'));
         $this->assertFalse($metable->fresh()->hasMeta('foo'));
+    }
+
+    public function test_it_can_delete_many_meta_at_once()
+    {
+        $this->useDatabase();
+        $metable = $this->createMetable();
+        $metable->setMeta('foo', 'bar');
+        $metable->setMeta('bar', 'baz');
+        $metable->setMeta('baz', 'foo');
+
+        $metable->removeManyMeta(['foo', 'bar', 'baz']);
+
+        $this->assertFalse($metable->hasMeta('foo'));
+        $this->assertFalse($metable->hasMeta('bar'));
+        $this->assertFalse($metable->hasMeta('baz'));
+
+        $metable = $metable->fresh();
+
+        $this->assertFalse($metable->hasMeta('foo'));
+        $this->assertFalse($metable->hasMeta('bar'));
+        $this->assertFalse($metable->hasMeta('baz'));
     }
 
     public function test_it_can_delete_all_meta()


### PR DESCRIPTION
This PR adds:
- `setManyMeta()` - to set multiple meta at once with an array of key/value pairs
- `removeManyMeta()` - to remove multiple meta at once with an array of keys (I needed this, and it was also requested in #35)

I've included supporting tests and documentation.

I also made some of the same changes that were made in #40 - if you're planning on merging _this_ PR, don't merge #40 yet and I'll merge this one into it and make sure that the changes line up.

Please let me know if you have any feedback or suggestions. Thanks!