### PR TITLE
Add `whereHasMetaType()` query scope

### DIFF
--- a/docs/source/querying_meta.rst
+++ b/docs/source/querying_meta.rst
@@ -31,6 +31,25 @@ You can also query for records that does not contain a meta key using the ``wher
     $models = MyModel::whereDoesntHaveMeta('notes')->get();
     $models = MyModel::whereDoesntHaveMeta(['queued_at', 'sent_at'])->get();
 
+Checking for Presence of a type
+-------------------------------
+
+To only return records that have a value assigned of a particular type, you can use ``whereHasMetaType()``. You can also pass an array to this method, which will cause the query to return any models attached to one or more of the provided types.
+
+::
+
+    <?php
+    $models = MyModel::whereHasMetaType('string')->get();
+    $models = MyModel::whereHasMetaType(['string', 'array'])->get();
+
+You may optionally provide one or more meta keys, which will restrict the query to only models with one or more of the provided keys with values that are one or more of the provided types.
+::
+
+    <?php
+    $models = MyModel::whereHasMetaType('array', 'tags')->get();
+    $models = MyModel::whereHasMetaType('datetime', ['queued_at', 'sent_at'])->get();
+    $models = MyModel::whereHasMetaType(['string', 'array'], 'notes')->get();
+
 Comparing value
 ---------------
 

--- a/src/Metable.php
+++ b/src/Metable.php
@@ -13,6 +13,7 @@ use Traversable;
  *
  * @property Collection|Meta[] $meta
  * @method static Builder whereHasMeta($key): void
+ * @method static Builder whereHasMetaType($type, $key = null): void
  * @method static Builder WhereDoesntHaveMeta($key)
  * @method static Builder WhereHasMetaKeys(array $keys)
  * @method static Builder WhereMeta(string $key, $operator, $value = null)
@@ -255,6 +256,30 @@ trait Metable
             '=',
             count($keys)
         );
+    }
+
+    /**
+     * Query scope to restrict the query to records which have `Meta` of a given type, optionally attached to a given key.
+     *
+     * If an array of types is passed instead, will restrict the query to records having one or more `Meta` with any of the types.
+     *
+     * If an array of keys is passed instead, will restrict the query to records having one or more `Meta` with any of the keys.
+     *
+     * @param Builder $q
+     * @param string|array $type
+     * @param string|array $key
+     *
+     * @return void
+     */
+    public function scopeWhereHasMetaType(Builder $q, $type, $key = null): void
+    {
+        $q->whereHas('meta', function (Builder $q) use ($type, $key) {
+            $q->whereIn('type', (array)$type);
+
+            if (isset($key)) {
+              $q->whereIn('key', (array)$key);
+            }
+        });
     }
 
     /**

--- a/src/Metable.php
+++ b/src/Metable.php
@@ -277,7 +277,7 @@ trait Metable
             $q->whereIn('type', (array)$type);
 
             if (isset($key)) {
-              $q->whereIn('key', (array)$key);
+                $q->whereIn('key', (array)$key);
             }
         });
     }

--- a/tests/Integration/MetableTest.php
+++ b/tests/Integration/MetableTest.php
@@ -299,12 +299,14 @@ class MetableTest extends TestCase
         $result3 = SampleMetable::whereHasMetaType('string', 'baz')->first();
         $result4 = SampleMetable::whereHasMetaType('array')->first();
         $result5 = SampleMetable::whereHasMetaType('array', 'baz')->first();
+        $result6 = SampleMetable::whereHasMetaType(['string', 'array'], 'baz')->first();
 
         $this->assertEquals($metable->getKey(), $result1->getKey());
         $this->assertEquals($metable->getKey(), $result2->getKey());
         $this->assertNull($result3);
         $this->assertEquals($metable->getKey(), $result4->getKey());
         $this->assertEquals($metable->getKey(), $result5->getKey());
+        $this->assertEquals($metable->getKey(), $result6->getKey());
     }
 
     public function test_it_can_order_query_by_meta_value()

--- a/tests/Integration/MetableTest.php
+++ b/tests/Integration/MetableTest.php
@@ -287,6 +287,26 @@ class MetableTest extends TestCase
         $this->assertNull($result2);
     }
 
+    public function test_it_can_be_queried_by_meta_type()
+    {
+        $this->useDatabase();
+        $metable = $this->createMetable();
+        $metable->setMeta('foo', 'bar');
+        $metable->setMeta('baz', ['a' => 'b']);
+
+        $result1 = SampleMetable::whereHasMetaType('string')->first();
+        $result2 = SampleMetable::whereHasMetaType('string', 'foo')->first();
+        $result3 = SampleMetable::whereHasMetaType('string', 'baz')->first();
+        $result4 = SampleMetable::whereHasMetaType('array')->first();
+        $result5 = SampleMetable::whereHasMetaType('array', 'baz')->first();
+
+        $this->assertEquals($metable->getKey(), $result1->getKey());
+        $this->assertEquals($metable->getKey(), $result2->getKey());
+        $this->assertNull($result3);
+        $this->assertEquals($metable->getKey(), $result4->getKey());
+        $this->assertEquals($metable->getKey(), $result5->getKey());
+    }
+
     public function test_it_can_order_query_by_meta_value()
     {
         $this->useDatabase();


### PR DESCRIPTION
I've recently come across scenarios where I needed to find meta values by _type_. This of course can be done with `whereHas()`:

```php
MyModel::whereHas('meta', fn ($query) => $query->where('type', 'string'));
```

I thought that it would be beneficial to others to be able to do the same thing though. In order to make it a bit more robust I added support for single or multiple types, as well as support for further limiting to single or multiple keys.

Here are some examples from the updated docs in this PR:

```php
// query only by type(s)
$models = MyModel::whereHasMetaType('string')->get();
$models = MyModel::whereHasMetaType(['string', 'array'])->get();

// query by type(s) and key(s)
$models = MyModel::whereHasMetaType('array', 'tags')->get();
$models = MyModel::whereHasMetaType('datetime', ['queued_at', 'sent_at'])->get();
$models = MyModel::whereHasMetaType(['string', 'array'], 'notes')->get();
```

---

A practical/real-world need for this is something that I did today. I have a meta key `added_tags_to_shipstation_order` that, up until now, has been a `string` of comma-separated tags. A situation arose where I needed to check if a specific tag was in the meta value. To support this (and other future needs) I had to query all models that had that meta key and convert the meta value from a `string` to an `array`. Using `whereHasMetaType()` made this process much easier:

```php
// get 50 orders to update
$orders = Order::whereHasMetaType('string', 'added_tags_to_shipstation_order')->take(50)->get();
```

This would exclude the `Order` records that I had already fixed (since their type is now `array`)

---

Let me know what you think and if you have any changes that you'd like me to make.

Thanks!