### PR TITLE
Support soft-deleted models and keep meta

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "plank/laravel-metable",
+    "name": "emild/laravel-metable",
     "description": "A package for attaching arbitrary data to Eloquent models",
     "type": "library",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "emild/laravel-metable",
+    "name": "plank/laravel-metable",
     "description": "A package for attaching arbitrary data to Eloquent models",
     "type": "library",
     "license": "MIT",

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -17,8 +17,9 @@ use Plank\Metable\DataType\Registry;
  * @property string $value
  * @property Model $metable
  */
-class Meta extends Model
+class Meta extends Model implements \OwenIt\Auditing\Contracts\Auditable
 {
+    use \OwenIt\Auditing\Auditable;
     /**
      * {@inheritdoc}
      */

--- a/src/Metable.php
+++ b/src/Metable.php
@@ -91,7 +91,7 @@ trait Metable
      *
      * @return void
      */
-    public function setManyMeta(array $metaDictionary): void
+    public function setManyMeta(array $metaDictionary, $triggerObservers = true): void
     {
         if (empty($metaDictionary)) {
             return;
@@ -101,7 +101,7 @@ trait Metable
         $builder = DB::table($prototype->getTable());
         $needReload = $this->relationLoaded('meta');
 
-        if (method_exists($builder, 'upsert')) {
+        if (method_exists($builder, 'upsert') && !$triggerObservers) {
             // use upsert if available to store all data in a single query
             // requires Laravel >8.0
             $metaModels = new Collection();

--- a/src/Metable.php
+++ b/src/Metable.php
@@ -39,7 +39,13 @@ trait Metable
     public static function bootMetable()
     {
         // delete all attached meta on deletion
-        static::deleted(function (self $model) {
+        static::deleted(function(self $model) {
+            if (!in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($model)))
+            {
+                $model->purgeMeta();
+            }
+        });
+        static::forceDeleted(function(self $model) {
             $model->purgeMeta();
         });
     }

--- a/src/Metable.php
+++ b/src/Metable.php
@@ -39,15 +39,19 @@ trait Metable
     public static function bootMetable()
     {
         // delete all attached meta on deletion
-        static::deleted(function(self $model) {
-            if (!in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($model)))
-            {
+        
+        if (!in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses(self::class)))
+        {
+            static::deleted(function(self $model) {
                 $model->purgeMeta();
-            }
-        });
-        static::forceDeleted(function(self $model) {
-            $model->purgeMeta();
-        });
+            });
+        }
+        else
+        {
+            static::forceDeleted(function(self $model) {
+                $model->purgeMeta();
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
This PR solves the issue of metas being deleted even if the metable model still exists (but soft-deleted).

The idea of soft-deleting is that it can be restored later on, or kept in the database for future use, logic, statistics etc.
Today, Metable just observe for deleted, but won't take SoftDeletion into consideration.

I tried to extend the Meta class, but as the observer is in the bootMetable function it cannot be overriden, thus this must exist natively in the package.