### PR TITLE
Add functionality for Explicit Parsing

### DIFF
--- a/src/Exceptions/DataTypeException.php
+++ b/src/Exceptions/DataTypeException.php
@@ -20,4 +20,9 @@ class DataTypeException extends Exception
 
         return new static("Meta handler not found for value of type '{$type}'");
     }
+
+    public static function handlerInvalid(string $class): self
+    {
+        return new static("Class'{$class}' is not a valid meta handler");
+    }
 }

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -49,6 +49,17 @@ class Meta extends Model
      */
     protected $cachedValue;
 
+    public function __construct(array $attributes = [])
+    {
+        if ($attributes['type'] ?? null) {
+            $this->forceFill(['type' => $attributes['type']]);
+
+            unset($attributes['type']);
+        }
+        parent::__construct($attributes);
+    }
+
+
     /**
      * Metable Relation.
      *
@@ -92,7 +103,10 @@ class Meta extends Model
     {
         $registry = $this->getDataTypeRegistry();
 
-        $this->attributes['type'] = $registry->getTypeForValue($value);
+        if ($this->isClean('type')) {
+            $this->attributes['type'] = $registry->getTypeForValue($value);
+        }
+
         $this->attributes['value'] = $registry->getHandlerForType($this->type)
             ->serializeValue($value);
 

--- a/src/Metable.php
+++ b/src/Metable.php
@@ -5,10 +5,10 @@ namespace Plank\Metable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
-use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Query\JoinClause;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
+use Plank\Metable\DataType\HandlerInterface;
+use Plank\Metable\Exceptions\DataTypeException;
 use Traversable;
 
 /**
@@ -568,11 +568,37 @@ trait Metable
 
         $meta = new $className([
             'key' => $key,
+            'type' => $this->getMetaType($key),
             'value' => $value,
         ]);
         $meta->metable_type = $this->getMorphClass();
         $meta->metable_id = $this->getKey();
 
         return $meta;
+    }
+
+    protected function getMetaType(string $key): ?string
+    {
+        $handlerClass = $this->getMetaCasts()[$key] ?? null;
+
+        if (! $handlerClass) {
+            return null;
+        }
+
+        if (! is_a($handlerClass, HandlerInterface::class, true)) {
+            throw DataTypeException::handlerInvalid($handlerClass);
+        }
+
+        return (new $handlerClass)->getDataType();
+    }
+
+    /**
+     * Use default casting for given Meta keys
+     *
+     * @return array<array-key, class-string<HandlerInterface>
+     */
+    protected function getMetaCasts(): array
+    {
+        return $this->metaCasts ?? [];
     }
 }

--- a/tests/Integration/DefaultHandlersMetableTest.php
+++ b/tests/Integration/DefaultHandlersMetableTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Plank\Metable\Tests\Integration;
+
+use Plank\Metable\Exceptions\DataTypeException;
+use Plank\Metable\Tests\Mocks\SampleMetableTypes;
+use Plank\Metable\Tests\TestCase;
+
+class DefaultHandlersMetableTest extends TestCase
+{
+
+    public function test_it_parses_given_variables_according_to_given_metaCasts()
+    {
+        $this->useDatabase();
+        $metable = $this->createMetable();
+
+        $metable->setMeta('fooBool', 'oooo');
+        $this->assertEquals(true, $metable->getMeta('fooBool'));
+
+        $metable->setMeta('fooBool', '');
+        $this->assertEquals(false, $metable->getMeta('fooBool'));
+
+        $metable->setMeta('fooString', 1234);
+        $this->assertEquals('1234', $metable->getMeta('fooString'));
+
+        $metable->setMeta('random', 1234); // auto choose
+        $this->assertEquals(1234, $metable->getMeta('random'));
+    }
+
+    public function test_it_throws_exception_if_metaCast_value_is_not_a_handler()
+    {
+        $this->useDatabase();
+        $metable = $this->createMetable();
+
+        $this->expectException(DataTypeException::class);
+
+        $metable->setMeta('fooWrong', 'oooo');
+
+    }
+
+
+    private function createMetable(array $attributes = []): SampleMetableTypes
+    {
+        return factory(SampleMetableTypes::class)->create($attributes);
+    }
+
+}

--- a/tests/Integration/DefaultHandlersMetableTest.php
+++ b/tests/Integration/DefaultHandlersMetableTest.php
@@ -8,7 +8,6 @@ use Plank\Metable\Tests\TestCase;
 
 class DefaultHandlersMetableTest extends TestCase
 {
-
     public function test_it_parses_given_variables_according_to_given_metaCasts()
     {
         $this->useDatabase();
@@ -35,13 +34,10 @@ class DefaultHandlersMetableTest extends TestCase
         $this->expectException(DataTypeException::class);
 
         $metable->setMeta('fooWrong', 'oooo');
-
     }
-
 
     private function createMetable(array $attributes = []): SampleMetableTypes
     {
         return factory(SampleMetableTypes::class)->create($attributes);
     }
-
 }

--- a/tests/Mocks/SampleMetableTypes.php
+++ b/tests/Mocks/SampleMetableTypes.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Plank\Metable\Tests\Mocks;
+
+use Illuminate\Database\Eloquent\Model;
+use Plank\Metable\DataType\BooleanHandler;
+use Plank\Metable\DataType\StringHandler;
+use Plank\Metable\Metable;
+
+class SampleMetableTypes extends Model
+{
+    use Metable;
+
+    protected $table = 'sample_metables';
+
+    protected $metaCasts = [
+        'fooBool' => BooleanHandler::class,
+        'fooString' => StringHandler::class,
+        'fooWrong' => SampleMetable::class
+    ];
+}

--- a/tests/factories/MetableFactory.php
+++ b/tests/factories/MetableFactory.php
@@ -2,11 +2,16 @@
 
 use Plank\Metable\Tests\Mocks\SampleMetable;
 use Plank\Metable\Tests\Mocks\SampleMetableSoftDeletes;
+use Plank\Metable\Tests\Mocks\SampleMetableTypes;
 
 $factory->define(SampleMetable::class, function (Faker\Generator $faker) {
     return [];
 });
 
 $factory->define(SampleMetableSoftDeletes::class, function (Faker\Generator $faker) {
+    return [];
+});
+
+$factory->define(SampleMetableTypes::class, function (Faker\Generator $faker) {
     return [];
 });


### PR DESCRIPTION
An approach to enforce explicit `DataTypes` on meta 

Please any feedback will be appreciated, and of course any change to fit in the package standards 

Todo:
* [x] tests
* [ ] add documentation

closes #85