### PR TITLE
Add an optional `Metable` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ php artisan migrate
 
 5. Add the `Plank\Metable\Metable` trait to any eloquent model class that you want to be able to attach metadata to.
 
-_Note: If need a more generic way to reference different Metable Model classes, you can optionally apply the `Plank\Metable\MetableInterface`_ to your models.
+_Note: If need a more generic way to reference different Metable Model classes, you can optionally apply the `Plank\Metable\MetableInterface` to your models._
 
 ```php
 <?php

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ php artisan migrate
 
 5. Add the `Plank\Metable\Metable` trait to any eloquent model class that you want to be able to attach metadata to.
 
-_Note: In case you need a more generic approach to Metable Models, you can use additionally the `Plank\Metable\MetableInterface`_
+_Note: If need a more generic way to reference different Metable Model classes, you can optionally apply the `Plank\Metable\MetableInterface`_ to your models.
 
 ```php
 <?php

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ php artisan migrate
 
 5. Add the `Plank\Metable\Metable` trait to any eloquent model class that you want to be able to attach metadata to.
 
+_Note: In case you need a more generic approach to Metable Models, you can use additionally the `Plank\Metable\MetableInterface`_
 
 ```php
 <?php

--- a/src/MetableInterface.php
+++ b/src/MetableInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Plank\Metable;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Collection;
+use Plank\Metable\Meta;
+
+/**
+ * @method static Builder whereHasMeta($key): void
+ * @method static Builder whereDoesntHaveMeta($key)
+ * @method static Builder whereHasMetaKeys(array $keys)
+ * @method static Builder whereMeta(string $key, $operator, $value = null)
+ * @method static Builder whereMetaNumeric(string $key, string $operator, $value)
+ * @method static Builder whereMetaIn(string $key, array $values)
+ * @method static Builder orderByMeta(string $key, string $direction = 'asc', $strict = false)
+ * @method static Builder orderByMetaNumeric(string $key, string $direction = 'asc', $strict = false)
+ */
+interface MetableInterface
+{
+    public function meta(): MorphMany;
+
+    public function setMeta(string $key, mixed $value): void;
+
+    public function setManyMeta(array $metaDictionary): void;
+
+    public function syncMeta(iterable $array): void;
+
+    /**
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function getMeta(string $key, mixed $default = null);
+
+    /**
+     * @return Collection<array-key, mixed>
+     */
+    public function getAllMeta(): Collection;
+
+    public function hasMeta(string $key): bool;
+
+    public function removeMeta(string $key): void;
+
+    public function removeManyMeta(array $keys): void;
+
+    public function purgeMeta(): void;
+
+    public function getMetaRecord(string $key): ?Meta;
+}


### PR DESCRIPTION
This request tries to add an extra highly optional interface, in order to be able to check our metable Models as instances.

For sure, I have used it to some projects that needs an increased typing strictness, however I am not sure if you find it handy to provide it and maintain it with your package. 

_Please proceed as you wish, without hesitating closing this PR_


Merge it after #87