### PR TITLE
Move `getDataType` method to abstract class

### DIFF
--- a/src/DataType/ArrayHandler.php
+++ b/src/DataType/ArrayHandler.php
@@ -5,16 +5,8 @@ namespace Plank\Metable\DataType;
 /**
  * Handle serialization of arrays.
  */
-class ArrayHandler implements HandlerInterface
+class ArrayHandler extends Handler
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getDataType(): string
-    {
-        return 'array';
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/DataType/BooleanHandler.php
+++ b/src/DataType/BooleanHandler.php
@@ -7,8 +7,5 @@ namespace Plank\Metable\DataType;
  */
 class BooleanHandler extends ScalarHandler
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected $type = 'boolean';
+    //
 }

--- a/src/DataType/DateTimeHandler.php
+++ b/src/DataType/DateTimeHandler.php
@@ -8,7 +8,7 @@ use DateTimeInterface;
 /**
  * Handle serialization of DateTimeInterface objects.
  */
-class DateTimeHandler implements HandlerInterface
+class DateTimeHandler extends Handler
 {
     /**
      * The date format to use for serializing.
@@ -16,14 +16,6 @@ class DateTimeHandler implements HandlerInterface
      * @var string
      */
     protected $format = 'Y-m-d H:i:s.uO';
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDataType(): string
-    {
-        return 'datetime';
-    }
 
     /**
      * {@inheritdoc}

--- a/src/DataType/FloatHandler.php
+++ b/src/DataType/FloatHandler.php
@@ -10,13 +10,8 @@ class FloatHandler extends ScalarHandler
     /**
      * {@inheritdoc}
      */
-    protected $type = 'double';
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDataType(): string
+    protected function getType(): string
     {
-        return 'float';
+        return 'double';
     }
 }

--- a/src/DataType/Handler.php
+++ b/src/DataType/Handler.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Plank\Metable\DataType;
+
+use Illuminate\Support\Str;
+
+abstract class Handler implements HandlerInterface
+{
+    public function getDataType(): string
+    {
+        return Str::of(static::class)
+            ->classBasename()
+            ->before('Handler')
+            ->lower()
+            ->__toString();
+    }
+}

--- a/src/DataType/IntegerHandler.php
+++ b/src/DataType/IntegerHandler.php
@@ -7,8 +7,5 @@ namespace Plank\Metable\DataType;
  */
 class IntegerHandler extends ScalarHandler
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected $type = 'integer';
+    //
 }

--- a/src/DataType/ModelCollectionHandler.php
+++ b/src/DataType/ModelCollectionHandler.php
@@ -66,7 +66,7 @@ class ModelCollectionHandler extends Handler
     /**
      * Load each model instance, grouped by class.
      *
-     * @param  array  $items
+     * @param array $items
      *
      * @return array
      */
@@ -77,7 +77,7 @@ class ModelCollectionHandler extends Handler
 
         // Retrieve a list of keys to load from each class.
         foreach ($items as $item) {
-            if (! is_null($item['key'])) {
+            if (!is_null($item['key'])) {
                 $classes[$item['class']][] = $item['key'];
             }
         }

--- a/src/DataType/ModelCollectionHandler.php
+++ b/src/DataType/ModelCollectionHandler.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Collection;
 /**
  * Handle serialization of Eloquent collections.
  */
-class ModelCollectionHandler implements HandlerInterface
+class ModelCollectionHandler extends Handler
 {
     /**
      * {@inheritdoc}
@@ -66,7 +66,7 @@ class ModelCollectionHandler implements HandlerInterface
     /**
      * Load each model instance, grouped by class.
      *
-     * @param array $items
+     * @param  array  $items
      *
      * @return array
      */
@@ -77,7 +77,7 @@ class ModelCollectionHandler implements HandlerInterface
 
         // Retrieve a list of keys to load from each class.
         foreach ($items as $item) {
-            if (!is_null($item['key'])) {
+            if (! is_null($item['key'])) {
                 $classes[$item['class']][] = $item['key'];
             }
         }

--- a/src/DataType/ModelHandler.php
+++ b/src/DataType/ModelHandler.php
@@ -7,16 +7,8 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Handle serialization of Eloquent Models.
  */
-class ModelHandler implements HandlerInterface
+class ModelHandler extends Handler
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getDataType(): string
-    {
-        return 'model';
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/DataType/NullHandler.php
+++ b/src/DataType/NullHandler.php
@@ -10,13 +10,8 @@ class NullHandler extends ScalarHandler
     /**
      * {@inheritdoc}
      */
-    protected $type = 'NULL';
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDataType(): string
+    public function getType(): string
     {
-        return 'null';
+        return 'NULL';
     }
 }

--- a/src/DataType/ObjectHandler.php
+++ b/src/DataType/ObjectHandler.php
@@ -5,16 +5,8 @@ namespace Plank\Metable\DataType;
 /**
  * Handle serialization of plain objects.
  */
-class ObjectHandler implements HandlerInterface
+class ObjectHandler extends Handler
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getDataType(): string
-    {
-        return 'object';
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/DataType/ScalarHandler.php
+++ b/src/DataType/ScalarHandler.php
@@ -5,21 +5,14 @@ namespace Plank\Metable\DataType;
 /**
  * Handle serialization of scalar values.
  */
-abstract class ScalarHandler implements HandlerInterface
+abstract class ScalarHandler extends Handler
 {
     /**
      * The name of the scalar data type.
-     *
-     * @var string
      */
-    protected $type;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDataType(): string
+    protected function getType(): string
     {
-        return $this->type;
+        return $this->getDataType();
     }
 
     /**
@@ -27,7 +20,7 @@ abstract class ScalarHandler implements HandlerInterface
      */
     public function canHandleValue($value): bool
     {
-        return gettype($value) == $this->type;
+        return gettype($value) == $this->getType();
     }
 
     /**
@@ -45,7 +38,7 @@ abstract class ScalarHandler implements HandlerInterface
      */
     public function unserializeValue(string $value)
     {
-        settype($value, $this->type);
+        settype($value, $this->getType());
 
         return $value;
     }

--- a/src/DataType/SerializableHandler.php
+++ b/src/DataType/SerializableHandler.php
@@ -7,16 +7,8 @@ use Serializable;
 /**
  * Handle serialization of Serializable objects.
  */
-class SerializableHandler implements HandlerInterface
+class SerializableHandler extends Handler
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getDataType(): string
-    {
-        return 'serializable';
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/DataType/StringHandler.php
+++ b/src/DataType/StringHandler.php
@@ -7,8 +7,5 @@ namespace Plank\Metable\DataType;
  */
 class StringHandler extends ScalarHandler
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected $type = 'string';
+    //
 }


### PR DESCRIPTION
As almost all Handlers keep a naming pattern, I added an Abstraction, which provides the same name based on the existing convention