### PR TITLE
Fix:Respect Metable model connection, while trying to save many meta

### DIFF
--- a/src/Metable.php
+++ b/src/Metable.php
@@ -90,7 +90,7 @@ trait Metable
             return;
         }
 
-        $builder = $this->meta()->newModelInstance();
+        $builder = $this->meta()->getBaseQuery();
         $needReload = $this->relationLoaded('meta');
 
         if (method_exists($builder, 'upsert')) {

--- a/src/Metable.php
+++ b/src/Metable.php
@@ -90,8 +90,7 @@ trait Metable
             return;
         }
 
-        $prototype = $this->meta()->newModelInstance();
-        $builder = DB::table($prototype->getTable());
+        $builder = $this->meta()->newModelInstance();
         $needReload = $this->relationLoaded('meta');
 
         if (method_exists($builder, 'upsert')) {


### PR DESCRIPTION
Using the `$model->setManyMeta` method, I got an error, as the trait tries to make a builder instance reading the model table.
While we use the `getBaseQuery`, we have already initialized the builder, so we can use it as it is


 

I am not sure if you need any tests on this change

Edit: It can Use the `DB::connection($prototype->getConnectionName())->table($prototype->getTable())` too