### PR TITLE
Add check for numeric string length

### DIFF
--- a/src/DataType/StringHandler.php
+++ b/src/DataType/StringHandler.php
@@ -14,7 +14,7 @@ class StringHandler extends ScalarHandler
 
     public function getNumericValue(mixed $value): null|int|float
     {
-        if (is_numeric($value)) {
+        if (is_numeric($value) && preg_match('/^-?(\d{1,20}(\.\d{1,16})?)$/', $value)) {
             return (float)$value;
         }
         return null;


### PR DESCRIPTION
Check numeric string length to fit into the database column.
When adding a meta with numeric string of length more than 20 characters a database exception occurs (if the database honours full column definition of `DECIMAL(36, 16)`). Adding a regular expression to check the length of integer and decimal parts will avoid that.